### PR TITLE
Filter huge bsdd report

### DIFF
--- a/application/bsdd_utils.py
+++ b/application/bsdd_utils.py
@@ -16,7 +16,13 @@ def get_hierarchical_bsdd(id):
         if model.status_bsdd != 'n':
             for bsdd_result in bsdd_task.results:
                 
-                bsdd_result = bsdd_result.serialize()
+                validity = (getattr(bsdd_result, a) for a in ('val_ifc_type', 'val_property_name', 'val_property_set', 'val_property_type', 'val_property_value'))
+                validity = (1 if v is None else v for v in validity)
+
+                if len(bsdd_task.results) > 16 and sum(validity) == 5:
+                    continue
+
+                bsdd_result = bsdd_result.serialize()              
              
                 if bsdd_result["instance_id"]:
                     inst = get_inst(bsdd_result["instance_id"])

--- a/application/templates/report_v2.html
+++ b/application/templates/report_v2.html
@@ -206,7 +206,7 @@
             <td colspan=9 class="rowheader">bSDD</td>
         </tr>
     
-        {% if results["bsdd_results"]["bsdd"] %}
+        {% if model.status_bsdd != 'n' %}
             {% for domain, classification_dicts in results["bsdd_results"]["bsdd"].items() %}
                 {% if domain == "no IfcClassification" %}
                     <tr><td style="text-align:center;background-color: {{validation_colors[2]}};" colspan=9>No classification in the file</td></tr>
@@ -320,6 +320,10 @@
                             
                         {% endfor %}
                 {% endif %}
+            {% else %}
+            <tr>
+                <td style="text-align:center;background-color: {{validation_colors[1]}};" colspan=9>Valid</td>
+            </tr>
             {% endfor %}
 
         {% else %}


### PR DESCRIPTION
When number of results exceeds 16 (arbitrary number) then hide rows that are valid on all 5 aspects. To speed up time to emit report.