### PR TITLE
Isolating bsdd

### DIFF
--- a/application/checks/check_bsdd_v2.py
+++ b/application/checks/check_bsdd_v2.py
@@ -186,8 +186,8 @@ def check_bsdd(ifc_fn, task_id, db):
                                     if sum([bsdd_result.val_ifc_type,val_results["pset_name"],val_results["property_name"], val_results["datatype"]], val_results["value"]) != 5:
                                         model.status_bsdd = 'i'
                                         #Validation output 
-                                        session.add(bsdd_result)
-                                        session.commit()
+                                    session.add(bsdd_result)
+                                    session.commit()
                                 else:
                                     bsdd_results.append(attrs)
 


### PR DESCRIPTION
Local tests can be invoked by : 
`python3 check_bsdd_v2.py --task 4 -db 0 -i input.ifc `
The output is a JSON file

Two additional questions:

- In the main.py folder, there is some further parsing of bsdd. Is this purely for the frontend or something we want to isolate for testing purposes as well?   https://github.com/Ghesselink/ifc-pipeline-validation/blob/6333d0c5424f0d33cba31fe89cea18d27284db7d/application/main.py#L599-L605

- Johan mentioned a --task functionality for the command line. Does this imply that the idea is to extent the script to other tasks (syntax, bsdd, gherkin, schema) ?