### PR TITLE
Paginate schema results

### DIFF
--- a/application/database.py
+++ b/application/database.py
@@ -174,7 +174,7 @@ class bsdd_validation_task(validation_task):
     }
     
 class schema_validation_task(validation_task):
-    results = relationship("schema_result")
+    results = relationship("schema_result", order_by='schema_result.constraint_type.asc(),schema_result.attribute.asc()')
 
     __mapper_args__ = {
         "polymorphic_identity": "schema_validation_task",
@@ -283,7 +283,10 @@ class schema_result(Base, Serializable):
     id = Column(Integer, primary_key=True)
     task_id = Column(Integer, ForeignKey('validation_tasks.id'))
     msg = Column(String, default="msg")
-
+    constraint_type = Column(Enum("uncategorized", 'schema', 'global_rule', 'simpletype_rule', 'entity_rule', name='schema_constraint_types'), default="uncategorized")
+    attribute = Column(String)
+    instance_id = Column(Integer, ForeignKey('instances.id'))
+    
     def __init__(self, task_id):
         self.task_id = task_id
 
@@ -294,6 +297,9 @@ class syntax_result(Base, Serializable):
     id = Column(Integer, primary_key=True)
     task_id = Column(Integer, ForeignKey('validation_tasks.id'))
     msg = Column(String, default="msg")
+    error_type = Column(Enum("uncategorized", 'unexpected_token', 'unexpected_character', 'duplicate_name', name='syntax_error_types'), default="uncategorized")
+    lineno = Column(Integer)
+    column = Column(Integer)
 
     def __init__(self, task_id):
         self.task_id = task_id


### PR DESCRIPTION
Flask endpoint to paginate schema results. 

The json can be invoked in the frontend as follows (the mentioned code should then be in Jinja on the frontend) : 

-  Get constraint types: 
```
(Pdb) results['constraint_types'] # access jsonified dictionary 'results'
['schema', 'global_rule', 'entity_rule'] 
```
Based on these constraint_types, it should be possible to make columns/headers, similar as in the work for schema headers (https://github.com/johltn/ifc-pipeline-validation/pull/10). Note that the returned constraint_types are only constraints of which values are found, not all the inputs for the columns in the database. https://github.com/AECgeeks/ifc-pipeline-validation/blob/a26426b4ade5bdc2bdd6cdae75defa933b34972e/application/database.py#L286

Each subcategory is then sliced and can be modified by calling the Flask API with start and end as parameters, similar as in https://github.com/johltn/ifc-pipeline-validation/blob/ui/application/main.py#L474 . The sorting is done by the work of Thomas in the database, which is also added to the current PR. https://github.com/AECgeeks/ifc-pipeline-validation/blob/a26426b4ade5bdc2bdd6cdae75defa933b34972e/application/database.py#L176-L177

Furthermore, it is possible to access all the (slice) by using the constraint types found by the earlier statement. 
For example (code will then be in Jinja on the front end): 
```
constraint types = results['constraint_types']
>> for constraint_type in constraint_types: #schema, global_rule, entity_rule
>>          results['values'][constraint_type]['saved_values] # returns all serialized schema_results with constraint type 'schema' (in first    iteration)
>>        result['values'][constraint_type][count] # returns count, similar as in earlier mentioned PR of Johan
```
