### PR TITLE
max characters

### DIFF
--- a/ui/src/SchemaResult.js
+++ b/ui/src/SchemaResult.js
@@ -67,8 +67,8 @@ export default function SchemaResult({ summary, content, status, instances }) {
                               return <tr>
                                 <td>{instances[row.instance_id] ? instances[row.instance_id].guid : '?'}</td>
                                 <td>{instances[row.instance_id] ? instances[row.instance_id].type : '?'}</td>
-                                <td><span class='pre'>{row.constraint_type !== 'schema' ? row.msg.split('\n').slice(2).join('\n') : row.msg}</span></td>
-                              </tr>
+                                <td><span class='pre'>{row.constraint_type !== 'schema' ? row.msg.split('\n').slice(2).flatMap(item => item.length > 75 ? item.match(/.{1,75}/g) : item).join('\n') : row.msg}</span></td>                            
+                            </tr>
                             })
                           }
                         </tbody>

--- a/ui/src/SchemaResult.js
+++ b/ui/src/SchemaResult.js
@@ -48,7 +48,11 @@ export default function SchemaResult({ summary, content, status, instances }) {
           ".MuiTreeItem-content.Mui-expanded .subcaption" : { visibility: "visible" },
           "table": { borderCollapse: 'collapse', fontSize: '80%' },
           "td, th": { padding: '0.2em 0.5em', verticalAlign: 'top' },
-          ".pre": { whiteSpace: 'pre' }
+          ".pre": {
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            // overflowWrap: 'break-word'
+          }
         }}
       >
         <TreeItem nodeId="0" label="Schema">
@@ -67,7 +71,7 @@ export default function SchemaResult({ summary, content, status, instances }) {
                               return <tr>
                                 <td>{instances[row.instance_id] ? instances[row.instance_id].guid : '?'}</td>
                                 <td>{instances[row.instance_id] ? instances[row.instance_id].type : '?'}</td>
-                                <td><span class='pre'>{row.constraint_type !== 'schema' ? row.msg.split('\n').slice(2).flatMap(item => item.length > 75 ? item.match(/.{1,75}/g) : item).join('\n') : row.msg}</span></td>                            
+                                <td><span class='pre'>{row.constraint_type !== 'schema' ? row.msg.split('\n').slice(2).join('\n') : row.msg}</span></td>
                             </tr>
                             })
                           }


### PR DESCRIPTION
'The right side of the error text is hidden in report. Making difficult to understand what the problem is'

https://bsi-technicalservices.atlassian.net/browse/VAL-203

The issue appeared only when the browser was not maximized in the screen. If it was (or in fullscreen), a scroll bar appeared below. 
A solution is to allow only for 75 characters in a row of a message and, if exceeded, display the rest of the text in a new row. 

Now, the result does not overflow.
![example](https://github.com/AECgeeks/ifc-pipeline-validation/assets/54070862/7d11f308-f609-4918-9f7c-67c07804aacf)
