### PR TITLE
adjust for border syntax check

### DIFF
--- a/ui/src/SyntaxResult.js
+++ b/ui/src/SyntaxResult.js
@@ -20,6 +20,28 @@ export default function SyntaxResult({ content, status }) {
     setRows(content.slice(page * 10, page * 10 + 10))
   }, [page, content]);
 
+  function renderMessage(error_instance, numWhitespace, numHighlight) {
+    const beforeHighlight = error_instance.substring(0, numWhitespace);
+    const highlightedChar = error_instance.substring(numWhitespace, numWhitespace + numHighlight);
+    const afterHighlight = error_instance.substring(numWhitespace + numHighlight);
+    return (
+      <React.Fragment>
+        {beforeHighlight}
+        <span
+          style={{
+            textDecoration: 'underline',
+            fontWeight: 'bold',
+            backgroundColor: '#ddd',
+            border: 'solid 1px red'
+          }}
+        >
+          {highlightedChar}
+        </span>
+        {afterHighlight}
+      </React.Fragment>
+    );
+  };
+
   return (
     <Paper sx={{overflow: 'hidden'}}>
       <TreeView
@@ -51,10 +73,23 @@ export default function SyntaxResult({ content, status }) {
         <TreeItem nodeId="0" label="Syntax">
         { rows.length
             ? rows.map(item => {
-              const msg_parts = item.msg.split('\n')
-              const whitespaces = msg_parts[msg_parts.length -1].match(/\s*/)[0].length;
-              const error_instance = msg_parts[msg_parts.length - 2]
-              const modifiedStr = `${error_instance.substring(0, whitespaces)}<span style='text-decoration:underline; font-weight:bold; background-color:#ddd;'>${error_instance[whitespaces]}</span>${error_instance.substring(whitespaces + 1)}`;
+              const msg_parts = item.msg.split('\n');
+              const [_, numWhitespace, numHighlight] = msg_parts[msg_parts.length -1].match(/(\s*)(\^+)/).map(s => s.length);
+              const error_instance = msg_parts[msg_parts.length - 2];
+
+              const errorMessage = renderMessage(
+                error_instance,
+                numWhitespace,
+                numHighlight
+              );
+
+
+              // const beforeHighlight = error_instance.substring(0, numWhitespace);
+              // const highlightedChar = error_instance.substring(numWhitespace, numWhitespace + numHighlight);
+              // const afterHighlight = error_instance.substring(numWhitespace + numHighlight);
+              
+            
+              // debugger;
 
                 return <TreeView defaultCollapseIcon={<ExpandMoreIcon />}
                   defaultExpandIcon={<ChevronRightIcon />}>
@@ -70,7 +105,7 @@ export default function SyntaxResult({ content, status }) {
                             <td>
                               <span class='pre'>{item.msg.split('\n').slice(0, -2).join('\n')}</span>
                               <br /> {}
-                              <span class='pre mono' dangerouslySetInnerHTML={{ __html: modifiedStr }}></span>
+                              <span class='pre mono'>{errorMessage}</span>
                             </td>
                           </tr>
                         </tbody>

--- a/ui/src/SyntaxResult.js
+++ b/ui/src/SyntaxResult.js
@@ -84,13 +84,6 @@ export default function SyntaxResult({ content, status }) {
               );
 
 
-              // const beforeHighlight = error_instance.substring(0, numWhitespace);
-              // const highlightedChar = error_instance.substring(numWhitespace, numWhitespace + numHighlight);
-              // const afterHighlight = error_instance.substring(numWhitespace + numHighlight);
-              
-            
-              // debugger;
-
                 return <TreeView defaultCollapseIcon={<ExpandMoreIcon />}
                   defaultExpandIcon={<ChevronRightIcon />}>
                     <TreeItem nodeId="syntax-0" label={<div class='caption'>{(item.error_type || 'syntax_error').replace('_', ' ')}</div>}>

--- a/ui/src/SyntaxResult.js
+++ b/ui/src/SyntaxResult.js
@@ -14,7 +14,7 @@ export default function SyntaxResult({ content, status }) {
 
   const handleChangePage = (_, newPage) => {
     setPage(newPage);
-  };  
+  };
 
   useEffect(() => {
     setRows(content.slice(page * 10, page * 10 + 10))
@@ -51,6 +51,10 @@ export default function SyntaxResult({ content, status }) {
         <TreeItem nodeId="0" label="Syntax">
         { rows.length
             ? rows.map(item => {
+              const msg_parts = item.msg.split('\n')
+              const whitespaces = msg_parts[4].match(/\s*/)[0].length;
+              const modifiedStr = `${msg_parts[3].substring(0, whitespaces)}<span style='text-decoration:underline; font-weight:bold; background-color:#ddd;'>${msg_parts[3][whitespaces]}</span>${msg_parts[3].substring(whitespaces + 1)}`;
+
                 return <TreeView defaultCollapseIcon={<ExpandMoreIcon />}
                   defaultExpandIcon={<ChevronRightIcon />}>
                     <TreeItem nodeId="syntax-0" label={<div class='caption'>{(item.error_type || 'syntax_error').replace('_', ' ')}</div>}>
@@ -64,7 +68,8 @@ export default function SyntaxResult({ content, status }) {
                             <td>{item.column}</td>
                             <td>
                               <span class='pre'>{item.msg.split('\n').slice(0, -2).join('\n')}</span>
-                              <span class='pre mono'>{item.msg.split('\n').slice(-2).join('\n')}</span>
+                              <br /> {}
+                              <span class='pre mono' dangerouslySetInnerHTML={{ __html: modifiedStr }}></span>
                             </td>
                           </tr>
                         </tbody>

--- a/ui/src/SyntaxResult.js
+++ b/ui/src/SyntaxResult.js
@@ -52,8 +52,9 @@ export default function SyntaxResult({ content, status }) {
         { rows.length
             ? rows.map(item => {
               const msg_parts = item.msg.split('\n')
-              const whitespaces = msg_parts[4].match(/\s*/)[0].length;
-              const modifiedStr = `${msg_parts[3].substring(0, whitespaces)}<span style='text-decoration:underline; font-weight:bold; background-color:#ddd;'>${msg_parts[3][whitespaces]}</span>${msg_parts[3].substring(whitespaces + 1)}`;
+              const whitespaces = msg_parts[msg_parts.length -1].match(/\s*/)[0].length;
+              const error_instance = msg_parts[msg_parts.length - 2]
+              const modifiedStr = `${error_instance.substring(0, whitespaces)}<span style='text-decoration:underline; font-weight:bold; background-color:#ddd;'>${error_instance[whitespaces]}</span>${error_instance.substring(whitespaces + 1)}`;
 
                 return <TreeView defaultCollapseIcon={<ExpandMoreIcon />}
                   defaultExpandIcon={<ChevronRightIcon />}>

--- a/ui/src/SyntaxResult.js
+++ b/ui/src/SyntaxResult.js
@@ -41,7 +41,10 @@ export default function SyntaxResult({ content, status }) {
           ".MuiTreeItem-content.Mui-expanded .subcaption" : { visibility: "visible" },
           "table": { borderCollapse: 'collapse', fontSize: '80%' },
           "td, th": { padding: '0.2em 0.5em', verticalAlign: 'top' },
-          ".pre": { whiteSpace: 'pre', display: 'block' },
+          ".pre": {
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          },
           ".mono": { fontFamily: 'monospace, monospace', marginTop: '0.3em' }
         }}
       >


### PR DESCRIPTION
Same as https://github.com/AECgeeks/ifc-pipeline-validation/pull/72, but for the syntax checks instead of schema. 

I've also looked at the gherkin checks, but here were no such issues. 

Before, the same issue:
![example_old](https://github.com/AECgeeks/ifc-pipeline-validation/assets/54070862/4de871cc-6e07-4a09-a43f-0448d34bfcad)

After:
![example_new](https://github.com/AECgeeks/ifc-pipeline-validation/assets/54070862/367ba480-bf65-4bd4-a814-0c4f5dd230a1)
